### PR TITLE
chore: add .clang-format file from minitalk

### DIFF
--- a/.vscode/.clang-format
+++ b/.vscode/.clang-format
@@ -1,0 +1,35 @@
+---
+Language: Cpp # This also applies to C
+UseTab: Always
+TabWidth: 4
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+BreakBeforeBraces: Custom


### PR DESCRIPTION
I guess I solved the issue, try to install the plugin from VSCode, and the necessary packages and everything should get formatted automatically. Try above all to put a space between the type and the variable name, like int space i, and it should automatically add a tab between. This was the main issue. 