### PR TITLE
return empty string in strip_ending_trailing_spaces if empty string

### DIFF
--- a/src/tokenizer/tokenizer.c
+++ b/src/tokenizer/tokenizer.c
@@ -5,6 +5,8 @@ char	*strip_ending_trailing_spaces(char const *str)
 	char	*trimmed;
 	int		end;
 
+	if (!str)
+		return (ft_strdup(""));
 	end = ft_strlen(str) - 1;
 	while (end >= 0 && ft_isspace(str[end]))
 		end--;


### PR DESCRIPTION
Fix for the seg fault on CTRL D (on emtpy string). CTRL D is still not exiting, but I'll try to solve this in another branch. 